### PR TITLE
Fix freeze function when the game window is scaled down

### DIFF
--- a/source/Engine/freeze.cpp
+++ b/source/Engine/freeze.cpp
@@ -89,7 +89,7 @@ void freezeGraphics() {
 			2.0f/realWinWidth*cameraZoom,                            .0,   .0,  .0,
 			                          .0, 2.0f/realWinHeight*cameraZoom,   .0,  .0,
 			                          .0,                            .0, 1.0f,  .0,
-			                        -1.0,                         -1.0f,   .0, 1.0f
+			 -2.0f*(x/realWinWidth)-1.0f,  -2.0f*(y/realWinHeight)-1.0f,   .0, 1.0f
 
 			};
 			for (int i = 0; i < 16; i++)


### PR DESCRIPTION
Fix freeze function when the game window is scaled down (game resolution is higher than displayed window).

Without this fix the first top-left part of the screen is drawed all the time.