### PR TITLE
Fix alpha blending of characters during freeze

### DIFF
--- a/source/Engine/graphics.cpp
+++ b/source/Engine/graphics.cpp
@@ -747,7 +747,7 @@ void setGraphicsWindow(bool fullscreen, bool restoreGraphics, bool resize) {
 	 */
 	glDisable(GL_DEPTH_TEST);
 	glDisable(GL_CULL_FACE);
-	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
 	setPixelCoords (false);
 
@@ -885,6 +885,11 @@ void setupOpenGLStuff() {
 			debugOut("ARB_fragment_shader supported.\n");
 		} else {
 			fatal("Error: Old graphics card! ARB_fragment_shader not supported.\n");
+		}
+		if (GLEW_EXT_blend_func_separate) {
+			debugOut("EXT_blend_func_separate supported.\n");
+		} else {
+			fatal("Error: Old graphics card! EXT_blend_func_separate not supported.\n");
 		}
 	}
 #else


### PR DESCRIPTION
The blending function did not set a correct value for resulting alpha channel. This had no effect on resulting image when drawing directly onto the screen, as the alpha channel was completely ignored in that case - it did however influence the resulting image if it was rendered first into a backdrop and only then displayed on screen. Incorrect alpha value would then cause unwanted blending to happen while drawing the backdrop, causing annoying darkening of sprites around their edges.